### PR TITLE
Fix - Use Python 3.8 instead of latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 .coverage
 cov_html/
+.env

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.8
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y postgresql-client


### PR DESCRIPTION
- Specify Python3.8 in Dockerfile to avoid unexpected behaviour with new Python versions. 
- Add `.env` to `.gitignore`.