### PR TITLE
Unsupported syntax in PostgreSQL database URI

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -5,7 +5,7 @@ import string
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 if os.environ.get("POSTGRES_DB") and os.environ.get("POSTGRES_USER") and os.environ.get("POSTGRES_PASSWORD") and os.environ.get("POSTGRES_HOSTNAME"):
-    DATABASE_URL = f'postgres://{os.environ.get("POSTGRES_USER")}:{os.environ.get("POSTGRES_PASSWORD")}@{os.environ.get("POSTGRES_HOSTNAME")}/{os.environ.get("POSTGRES_DB")}'
+    DATABASE_URL = f'postgresql://{os.environ.get("POSTGRES_USER")}:{os.environ.get("POSTGRES_PASSWORD")}@{os.environ.get("POSTGRES_HOSTNAME")}/{os.environ.get("POSTGRES_DB")}'
 else:
     DATABASE_URL = "sqlite:///" + os.path.join(basedir, "app.db")
 


### PR DESCRIPTION
"The URI should start with postgresql:// instead of postgres://. SQLAlchemy used to accept both, but has removed support for the postgres name." This comment from SO fixed problem with the database.